### PR TITLE
Add `logger.debug` call to log HTTP requests

### DIFF
--- a/patches/activity/005_log_request.patch
+++ b/patches/activity/005_log_request.patch
@@ -1,0 +1,14 @@
+diff -r -c target/ya_activity/rest.py src/ya_activity/rest.py
+*** target/ya_activity/rest.py	2020-10-02 09:21:59.408269422 +0200
+--- src/ya_activity/rest.py	2020-10-02 09:22:27.589944886 +0200
+***************
+*** 165,170 ****
+--- 165,172 ----
+                           declared content type."""
+                  raise ApiException(status=0, reason=msg)
+  
++         logger.debug("request: %s", args)
++ 
+          r = await self.pool_manager.request(**args)
+          if _preload_content:
+  

--- a/patches/market/005_log_request.patch
+++ b/patches/market/005_log_request.patch
@@ -1,0 +1,14 @@
+diff -r -c target/ya_market/rest.py src/ya_market/rest.py
+*** target/ya_market/rest.py	2020-10-02 09:21:59.416268733 +0200
+--- src/ya_market/rest.py	2020-10-02 09:27:26.513940917 +0200
+***************
+*** 165,170 ****
+--- 165,172 ----
+                           declared content type."""
+                  raise ApiException(status=0, reason=msg)
+  
++         logger.debug("request: %s", args)
++ 
+          r = await self.pool_manager.request(**args)
+          if _preload_content:
+  

--- a/patches/payment/005_log_request.patch
+++ b/patches/payment/005_log_request.patch
@@ -1,0 +1,14 @@
+diff -r -c target/ya_payment/rest.py src/ya_payment/rest.py
+*** target/ya_payment/rest.py	2020-10-02 09:21:59.428267699 +0200
+--- src/ya_payment/rest.py	2020-10-02 09:27:26.473942367 +0200
+***************
+*** 165,170 ****
+--- 165,172 ----
+                           declared content type."""
+                  raise ApiException(status=0, reason=msg)
+  
++         logger.debug("request: %s", args)
++ 
+          r = await self.pool_manager.request(**args)
+          if _preload_content:
+  


### PR DESCRIPTION
HTTP responses are logged with level `DEBUG` to the loggers named `<module>.rest`, where `<module>` is `ya_activity`, `ya_market` or `ya_payments`.

This PR adds similar logging for HTTP requests.