### PR TITLE
Add event_date field to classes related to debit note and invoice events

### DIFF
--- a/build-scripts/add_event_date_field.sh
+++ b/build-scripts/add_event_date_field.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+while IFS= read line
+do
+  if [[ $line =~ "openapi_types =" ]]; then
+    printf "$line\n"
+    printf "        'event_date': 'datetime',\n"
+  elif [[ $line =~ "attribute_map =" ]]; then
+    printf "$line\n"
+    printf "        'event_date': 'eventDate',\n"
+  elif [[ $line =~ "self.discriminator = None" ]]; then
+    printf "        self._event_date = None\n"
+    printf "$line\n"
+    printf "        if event_date is not None:\n"
+    printf "            self.event_date = event_date\n"
+  elif [[ $line =~ "def to_dict" ]]; then
+    printf "    @property\n"
+    printf "    def event_date(self):\n"
+    printf "        return self._event_date\n"
+    printf "\n"
+    printf "    @event_date.setter\n"
+    printf "    def event_date(self, event_date):\n"
+    printf "        self._event_date = event_date\n"
+    printf "\n"
+    printf "$line\n"
+  elif [[ $line =~ "local_vars_configuration=None" ]]; then
+    printf "$line\n" | sed 's/local_vars_configuration=None/local_vars_configuration=None, event_date=None/'
+  else
+    printf "$line\n"
+  fi
+done

--- a/build-scripts/apply-patches.sh
+++ b/build-scripts/apply-patches.sh
@@ -45,6 +45,12 @@ apply_patches() {
     done
   done
 
+  echo script patches
+  FILES=$(ls ../src/ya_payment/models/*event*py | grep -v all_of | grep -v /event_type.py | grep -v /invoice_event.py | grep -v /debit_note_event.py)
+  for file in $FILES ; do
+    ./add_event_date_field.sh <$file >TMP_FILE
+    mv TMP_FILE $file
+  done
 }
 echo step 3 apply patches
 apply_patches "src" "$MODULES"

--- a/build-scripts/apply-patches.sh
+++ b/build-scripts/apply-patches.sh
@@ -46,9 +46,9 @@ apply_patches() {
   done
 
   echo script patches
-  FILES=$(ls ../src/ya_payment/models/*event*py | grep -v all_of | grep -v /event_type.py | grep -v /invoice_event.py | grep -v /debit_note_event.py)
+  FILES=$(ls src/ya_payment/models/*event*py | grep -v all_of | grep -v /event_type.py | grep -v /invoice_event.py | grep -v /debit_note_event.py)
   for file in $FILES ; do
-    ./add_event_date_field.sh <$file >TMP_FILE
+    ./build-scripts/add_event_date_field.sh <$file >TMP_FILE
     mv TMP_FILE $file
   done
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ya-aioclient"
-version = "0.7.0"
+version = "0.6.4"
 description = ""
 authors = ["Przemysław K. Rekucki <prekucki@rcl.pl>"]
 license = "LGPL-3.0-or-later"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ya-aioclient"
-version = "0.6.3"
+version = "0.7.0"
 description = ""
 authors = ["Przemysław K. Rekucki <prekucki@rcl.pl>"]
 license = "LGPL-3.0-or-later"


### PR DESCRIPTION
# Alternative solution: https://github.com/golemfactory/ya-py-aioclient/pull/23
## (only one of them should be merged)





This script adds `event_date` field to classes related to debit note and invoice events, e.g. `ya_payment/models/payment_received_event.py` is modified like this:
```diff
@@ -31,21 +31,26 @@
                             and the value is json key in definition.
     """
     openapi_types = {
+        'event_date': 'datetime',
         'payment_id': 'str'
     }
 
     attribute_map = {
+        'event_date': 'eventDate',
         'payment_id': 'paymentId'
     }
 
-    def __init__(self, payment_id=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, payment_id=None, local_vars_configuration=None, event_date=None):  # noqa: E501
         """PaymentReceivedEvent - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
         self.local_vars_configuration = local_vars_configuration
 
         self._payment_id = None
+        self._event_date = None
         self.discriminator = None
+        if event_date is not None:
+            self.event_date = event_date
 
         if payment_id is not None:
             self.payment_id = payment_id
@@ -71,6 +76,14 @@
 
         self._payment_id = payment_id
 
+    @property
+    def event_date(self):
+        return self._event_date
+
+    @event_date.setter
+    def event_date(self, event_date):
+        self._event_date = event_date
+
     def to_dict(self):
         """Returns the model properties as a dict"""
         result = {}
```